### PR TITLE
Update source element to remove deprecated 'src'

### DIFF
--- a/layouts/partials/helpers/lib-output/image-handling/source-element.html
+++ b/layouts/partials/helpers/lib-output/image-handling/source-element.html
@@ -1,10 +1,11 @@
 {{- $ctx := . -}}
 {{- $inImgMap := .imgMap -}}
 {{- $inPage := .page -}}
-{{- $inUseSrcSet := .useSrcSet -}}
 {{- $inSizesAttr := .sizesAttr -}}
 {{- $inMedia := .media -}}
-<source src="{{ $inImgMap.finalSrc }}" media="{{ $inMedia }}"
-{{ if and (ge (len $inImgMap.srcSet) 1) $inUseSrcSet -}}
+<source media="{{ $inMedia }}"
+{{ if and (ge (len $inImgMap.srcSet) 1) -}}
     srcset="{{ delimit $inImgMap.srcSet ", " }}" sizes="{{ $inSizesAttr }}"
+{{- else -}}
+    srcset="{{ $inImgMap.finalSrc }}" sizes="{{ $inSizesAttr }}"
 {{- end -}}>

--- a/layouts/partials/helpers/lib-output/image-handling/thumbnail-or-full-picture.html
+++ b/layouts/partials/helpers/lib-output/image-handling/thumbnail-or-full-picture.html
@@ -101,11 +101,11 @@
     {{- if $usePicture -}}
         <picture{{ with $class }} class="{{ . }}"{{ end }}>
         {{- if and $thumbnails (ne $thumbnailImgMap.finalSrc "") -}}
-            {{- $sourceOptions := (dict "imgMap" $thumbnailImgMap "page" . "useSrcSet" (cond (ge (len $thumbnailImgMap.srcSet) 1) true false) "sizesAttr" $thumbnailSizesAttr "media" $thumbnailMedia) -}}
+            {{- $sourceOptions := (dict "imgMap" $thumbnailImgMap "page" . "sizesAttr" $thumbnailSizesAttr "media" $thumbnailMedia) -}}
             {{- partial "helpers/lib-output/image-handling/source-element" $sourceOptions -}}
         {{- end -}}
         {{- if and $fullSize (ne $fullImgMap.finalSrc "") -}}
-            {{- $sourceOptions := (dict "imgMap" $fullImgMap "page" . "useSrcSet" (cond (ge (len $fullImgMap.srcSet) 1) true false) "sizesAttr" $sizesAttr) -}}
+            {{- $sourceOptions := (dict "imgMap" $fullImgMap "page" . "sizesAttr" $sizesAttr) -}}
             {{- partial "helpers/lib-output/image-handling/source-element" $sourceOptions -}}
         {{- end -}}
         {{- $class := "" -}}


### PR DESCRIPTION
source in a picture element should not use 'src'. It should use only 'srcset'. Therefore update to use srcset where we used to use src.

Closes #46

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>