### PR TITLE
Add deployment to Netlify for CI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,3 @@
 [module.hugoVersion]
 min = "0.96.0"
 extended = false
-

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,0 +1,195 @@
+baseURL = "https://image-handling-mod-ci.demo.wildtechgarden.com/"
+copyright = "© 2021-2023 Daniel F. Dickinson"
+defaultContentLanguage = "en"
+homepage = "https://github.com/danielfdickinson/image-handling-mod-hugo-dfd"
+enableGitInfo = true
+enableRobotsTXT = true
+summaryLength = 25
+disableKinds = ["sitemap","RSS"]
+timeout = 90000
+
+[taxonomies]
+tag = "tags"
+
+[outputFormats]
+[outputFormats.nredirects]
+baseName = "_redirects"
+isPlainText = true
+mediaType = "text/nredirects"
+
+[mediaTypes]
+[mediaTypes."text/nredirects"]
+suffixes = [""]
+
+[outputs]
+home = ["HTML", "RSS", "nredirects"]
+
+[params]
+imageConvertTo = "webp"
+mainSections = ["post"]
+redirectsDomains = [
+	"http://image-handling-mod-ci.netlify.app/* https://image-handling-mod-ci.demo.wildtechgarden.com/:splat 301!",
+	"https://image-handling-mod-ci.netlify.app/* https://image-handling-mod-ci.demo.wildtechgarden.com/:splat 301!",
+	"http://image-handling-mod.demo-ci.wildtechgarden.com/* https://image-handling-mod-ci.demo.wildtechgarden.com/:splat 301!"
+]
+# Footnotes and TableOfContents don't work properly with a base href set in <head>, but we don't use either for this site.
+useBaseURL = true
+
+[[cascade]]
+pageCanonical = false
+
+
+[menu]
+[[menu.main]]
+identifier = "about"
+name = "About"
+pageref = "about"
+weight = 10
+
+[[menu.main]]
+identifier = "accessibility"
+name = "Accessibility"
+pageref = "accessibility"
+weight = 20
+
+# See https://gohugo.io/content-management/multilingual/
+# and https://www.regisphilibert.com/blog/2018/08/hugo-multilingual-part-1-managing-content-translation/
+[languages]
+[languages.en]
+languageName = "English"
+title = "Demo Site for DFD Image Handling Hugo Module"
+description = "Demo site for Hugo module for handling images and image-related functionality for themes"
+weight = 1
+
+[author]
+name = "Daniel F. Dickinson"
+homepage = "https://www.danielfdickinson.ca/"
+email = "dfdpublic@wildtechgarden.ca"
+
+[[author.authors]]
+name = "Daniel F. Dickinson"
+homepage = "https://www.danielfdickinson.ca/"
+email = "dfdpublic@wildtechgarden.ca"
+
+[frontmatter]
+publishDate = ["publishDate","date",":git","lastmod",":fileModTime"]
+lastmod = ["lastmod",":git",":fileModTime","date","publishDate"]
+date = ["date","publishDate","lastmod",":git",":fileModTime"]
+
+[markup]
+[markup.highlight]
+guessSyntax = true
+noClasses = false
+
+[privacy]
+
+[privacy.vimeo]
+disabled = true
+
+[privacy.twitter]
+disabled = true
+
+[privacy.instagram]
+disabled = true
+
+[privacy.youtube]
+disabled = true
+
+[module]
+
+[[module.mounts]]
+source = "../static"
+target = "static"
+
+[[module.mounts]]
+source = "../layouts"
+target = "layouts"
+
+[[module.mounts]]
+source = "../README.md"
+target = "assets/README-dfd-image-handling.md"
+
+[[module.mounts]]
+source = "../LICENSE"
+target = "static/LICENSE"
+
+[[module.mounts]]
+source = "../ACKNOWLEDGEMENTS.md"
+target = "content/post/ACKNOWLEDGEMENTS.md"
+
+[[module.mounts]]
+source = "../README-NOTES.md"
+target = "content/post/README-NOTES.md"
+
+[[module.mounts]]
+source = "../i18n"
+target = "i18n"
+
+[[module.imports]]
+path = "github.com/danielfdickinson/image-handling-mod-demo"
+ignoreConfig = true
+ignoreImports = true
+
+[[module.imports.mounts]]
+source = "static"
+target = "static"
+
+[[module.imports.mounts]]
+source = "layouts"
+target = "layouts"
+
+[[module.imports.mounts]]
+source = "data"
+target = "data"
+
+[[module.imports.mounts]]
+source = "assets"
+target = "assets"
+
+[[module.imports.mounts]]
+source = "i18n"
+target = "i18n"
+
+[[module.imports.mounts]]
+source = "archetypes"
+target = "archetypes"
+
+[[module.imports.mounts]]
+source = "content"
+target = "content"
+
+[[module.imports.mounts]]
+source = "README-assets"
+target = "assets/README-assets"
+
+[[module.imports]]
+path = "github.com/danielfdickinson/minimal-test-theme-hugo-dfd"
+ignoreConfig = true
+ignoreImports = true
+
+[[module.imports.mounts]]
+source = "static"
+target = "static"
+
+[[module.imports.mounts]]
+source = "layouts"
+target = "layouts"
+
+[[module.imports.mounts]]
+source = "data"
+target = "data"
+
+[[module.imports.mounts]]
+source = "assets"
+target = "assets"
+
+[[module.imports.mounts]]
+source = "i18n"
+target = "i18n"
+
+[[module.imports.mounts]]
+source = "archetypes"
+target = "archetypes"
+
+[[module.imports]]
+path = "github.com/danielfdickinson/link-handling-mod-hugo-dfd"

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,9 @@
+module github.com/danielfdickinson/image-handling-mod-hugo-dfd/exampleSite
+
+go 1.20
+
+require (
+	github.com/danielfdickinson/image-handling-mod-demo v0.0.0-20230401193704-969df2e45e12 // indirect
+	github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.3-0.20221028012233-aa14c648c5a2 // indirect
+	github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.4.4-0.20221028020841-ed00480e7085 // indirect
+)

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,0 +1,8 @@
+github.com/danielfdickinson/image-handling-mod-demo v0.0.0-20230401193704-969df2e45e12 h1:doJJx3renU0Lw/v2LPrg03GFQ0kT212CmtLiepTYYBw=
+github.com/danielfdickinson/image-handling-mod-demo v0.0.0-20230401193704-969df2e45e12/go.mod h1:zwQNYTRvzTBBcP39pHa6KXYV9roLPv5tywFSYTMwbRs=
+github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.0.0-20230331134055-5f491176decf/go.mod h1:h+vNqbDFVmrcnlUq1GsWtKS3HWw7wLDqM1PahGQjSOY=
+github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.3-0.20220801020716-c28b4bdbab3e/go.mod h1:ajYr1qZHU5FJloKLT9rF8jSzKhuv5uSzQ/kA5M1vsY8=
+github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.3-0.20221028012233-aa14c648c5a2 h1:e1kf4nRllGvzSDz6OvHbfCgoANBGUH95NsOAtNrCAMw=
+github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.3-0.20221028012233-aa14c648c5a2/go.mod h1:ajYr1qZHU5FJloKLT9rF8jSzKhuv5uSzQ/kA5M1vsY8=
+github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.4.4-0.20221028020841-ed00480e7085 h1:AJc8eN55ayWkvSR1Nw39fUIXeeEsAuuwLykEPZuSC2c=
+github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.4.4-0.20221028020841-ed00480e7085/go.mod h1:6NZ/CEGWWMq2Xj1QMVmjUlWjNVfAinHndltjTdzIG7o=

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,5 @@ module github.com/danielfdickinson/image-handling-mod-hugo-dfd
 
 go 1.15
 
+require (
+)

--- a/scripts/netlify_build.sh
+++ b/scripts/netlify_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$CONTEXT" = "production" ]; then
+	export HUGO_PARAMS_DEPLOYEDBASEURL="$URL"
+else
+	export HUGO_PARAMS_DEPLOYEDBASEURL="$DEPLOY_PRIME_URL"
+fi
+
+HUGO_RESOURCEDIR="$(pwd)/resources" hugo --gc --minify -b $URL --source exampleSite --destination $(pwd)/public --config config.toml

--- a/words-project.txt
+++ b/words-project.txt
@@ -1,5 +1,6 @@
 errorf
 isset
+nredirects
 plainify
 warnf
 webp


### PR DESCRIPTION
This repo only deploys for CI; the demo site is deployed via the
corresponding demo site repo using the last release of this module.
Currently that is just the tip of 'main' in this repo, but that will
change.